### PR TITLE
Fix security alert for tensorflow

### DIFF
--- a/projects/parkinglot/streamlit_app/Mask_RCNN/requirements.txt
+++ b/projects/parkinglot/streamlit_app/Mask_RCNN/requirements.txt
@@ -4,8 +4,8 @@ Pillow
 cython
 matplotlib
 scikit-image
-tensorflow==1.14
-keras==2.2.5
+tensorflow>=1.15.2
+keras>=2.3.1
 opencv-python
 h5py
 imgaug


### PR DESCRIPTION
Per https://github.com/1904labs/learn-data-science/network/alert/projects/parkinglot/streamlit_app/Mask_RCNN/requirements.txt/tensorflow/open we need to change minimal version of tensorflow to >= 1.15.2
Also bumped to latest keras >2.3.1